### PR TITLE
Update dependencies to most recent version, fixes MSAA limitation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-egui_wgpu_backend = "0.6"
-egui = "0.11.0"
-winit = "0.24"
-nannou = "0.16"
+egui_wgpu_backend = "0.10"
+egui = "0.13.1"
+winit = "0.25"
+nannou = "0.17.1"

--- a/examples/circle_packing.rs
+++ b/examples/circle_packing.rs
@@ -70,7 +70,7 @@ impl Model {
                 radius,
                 color,
             };
-            
+
             loops += 1;
             if loops > 20000 {
                 break;
@@ -121,13 +121,12 @@ fn model(app: &App) -> Model {
     let window_id = app
         .new_window()
         .view(view)
-        .msaa_samples(1)
         .raw_event(raw_window_event)
         .build()
         .unwrap();
 
     let window = app.window(window_id).unwrap();
-    Model::new(EguiBackend::new(&window))
+    Model::new(EguiBackend::from_window(&window))
 }
 
 fn update(_app: &App, model: &mut Model, _update: Update) {

--- a/examples/tune_color.rs
+++ b/examples/tune_color.rs
@@ -23,7 +23,6 @@ fn model(app: &App) -> Model {
     let window_id = app
         .new_window()
         .title("Nannou + Egui")
-        .msaa_samples(1)
         .raw_event(raw_window_event) // This is where we forward all raw events for egui to process them
         .view(view) // The function that will be called for presenting graphics to a frame.
         .build()
@@ -32,7 +31,7 @@ fn model(app: &App) -> Model {
     let window = app.window(window_id).unwrap();
 
     Model {
-        egui_backend: nannou_egui::EguiBackend::new(&window),
+        egui_backend: nannou_egui::EguiBackend::from_window(&window),
         radius: 40.0,
         color: hsv(10.0, 0.5, 1.0),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,7 @@ use egui_wgpu_backend::ScreenDescriptor;
 use winit::event::VirtualKeyCode;
 use winit::event::WindowEvent::*;
 
-const OUTPUT_FORMAT: egui_wgpu_backend::wgpu::TextureFormat =
-    egui_wgpu_backend::wgpu::TextureFormat::Rgba16Float;
+const OUTPUT_FORMAT: egui_wgpu_backend::wgpu::TextureFormat = nannou::Frame::TEXTURE_FORMAT;
 
 pub struct EguiBackend {
     render_pass: RefCell<egui_wgpu_backend::RenderPass>,
@@ -25,7 +24,7 @@ pub struct EguiBackend {
 }
 
 impl EguiBackend {
-    pub fn new(window: &nannou::window::Window) -> EguiBackend {
+    pub fn from_window(window: &nannou::window::Window) -> EguiBackend {
         let scale_factor = window.scale_factor() as f64;
         let width = window.inner_size_pixels().0;
         let height = window.inner_size_pixels().1;
@@ -47,6 +46,7 @@ impl EguiBackend {
             render_pass: RefCell::new(egui_wgpu_backend::RenderPass::new(
                 window.swap_chain_device(),
                 OUTPUT_FORMAT,
+                window.msaa_samples(),
             )),
             context,
             modifier_state: winit::event::ModifiersState::empty(),


### PR DESCRIPTION
Updates:
- `nannou` 0.16 -> 0.17.1
- `egui` 0.10 -> 0.13.1
- `egui_wgpu_backend` 0.6 -> 0.10

It looks like the latest version of the egui wgpu backend can now handle
MSAA other than 1. Closes #3.

I also renamed the `EguiBackend` constructor from `new` to
`from_window`, as I think it might be worth adding some more
constructors e.g. for targeting non-window-frame textures, or
`from_app` where the default window is selected automatically, etc.

I'll likely do some more hacking on this today, I plan on trying to
solve #4.