### PR TITLE
Update to nannou 0.18.1, wgpu 0.11, egui 0.15, egui_wgpu_backend 0.14.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,3 @@ members = [
 
 # wgpu requires feature resolver 2.
 resolver = "2"
-
-[patch.crates-io]
-nannou = { git = "https://github.com/mitchmindtree/nannou", branch = "wgpu-0.10" }
-nannou_core = { git = "https://github.com/mitchmindtree/nannou", branch = "wgpu-0.10" }
-nannou_wgpu = { git = "https://github.com/mitchmindtree/nannou", branch = "wgpu-0.10" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,11 @@ members = [
     "nannou_egui",
     "nannou_egui_demo_app",
 ]
+
+# wgpu requires feature resolver 2.
+resolver = "2"
+
+[patch.crates-io]
+nannou = { git = "https://github.com/mitchmindtree/nannou", branch = "wgpu-0.10" }
+nannou_core = { git = "https://github.com/mitchmindtree/nannou", branch = "wgpu-0.10" }
+nannou_wgpu = { git = "https://github.com/mitchmindtree/nannou", branch = "wgpu-0.10" }

--- a/nannou_egui/Cargo.toml
+++ b/nannou_egui/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/AlexEne/nannou_egui"
 readme = "../README.md"
 
 [dependencies]
-egui_wgpu_backend = "0.12"
-egui = "0.14.0"
+egui_wgpu_backend = "0.14"
+egui = "0.15.0"
 winit = "0.25"
-nannou = "0.17.1"
+nannou = "0.18.1"

--- a/nannou_egui/Cargo.toml
+++ b/nannou_egui/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/AlexEne/nannou_egui"
 readme = "../README.md"
 
 [dependencies]
-egui_wgpu_backend = "0.10"
-egui = "0.13.1"
+egui_wgpu_backend = "0.12"
+egui = "0.14.0"
 winit = "0.25"
 nannou = "0.17.1"

--- a/nannou_egui/src/lib.rs
+++ b/nannou_egui/src/lib.rs
@@ -80,7 +80,7 @@ impl Egui {
 
     /// Construct a `Egui` associated with the given window.
     pub fn from_window(window: &nannou::window::Window) -> Self {
-        let device = window.swap_chain_device();
+        let device = window.device();
         let format = nannou::Frame::TEXTURE_FORMAT;
         let msaa_samples = window.msaa_samples();
         let scale_factor = window.scale_factor();
@@ -117,9 +117,12 @@ impl Egui {
     }
 
     /// Draws the contents of the inner `context` to the given frame.
-    pub fn draw_to_frame(&self, frame: &nannou::Frame) {
+    pub fn draw_to_frame(
+        &self,
+        frame: &nannou::Frame,
+    ) -> Result<(), egui_wgpu_backend::BackendError> {
         let mut renderer = self.renderer.borrow_mut();
-        renderer.draw_to_frame(&self.context, frame);
+        renderer.draw_to_frame(&self.context, frame)
     }
 
     /// Provide access to an `epi::Frame` within the given function.
@@ -313,7 +316,7 @@ impl Renderer {
 
     /// Construct a `Renderer` ready for drawing to the given window.
     pub fn from_window(window: &nannou::window::Window) -> Self {
-        let device = window.swap_chain_device();
+        let device = window.device();
         let format = nannou::Frame::TEXTURE_FORMAT;
         let msaa_samples = window.msaa_samples();
         Self::new(device, format, msaa_samples)
@@ -329,7 +332,7 @@ impl Renderer {
         dst_size_pixels: [u32; 2],
         dst_scale_factor: f32,
         dst_texture: &wgpu::TextureView,
-    ) {
+    ) -> Result<(), egui_wgpu_backend::BackendError> {
         let render_pass = &mut self.render_pass;
         let paint_jobs = &self.paint_jobs;
         let [physical_width, physical_height] = dst_size_pixels;
@@ -338,14 +341,18 @@ impl Renderer {
             physical_height,
             scale_factor: dst_scale_factor,
         };
-        render_pass.update_texture(device, queue, &context.texture());
+        render_pass.update_texture(device, queue, &*context.texture());
         render_pass.update_user_textures(&device, &queue);
         render_pass.update_buffers(device, queue, &paint_jobs, &screen_descriptor);
-        render_pass.execute(encoder, dst_texture, &paint_jobs, &screen_descriptor, None);
+        render_pass.execute(encoder, dst_texture, &paint_jobs, &screen_descriptor, None)
     }
 
     /// Encodes a render pass for drawing the given context's texture to the given frame.
-    pub fn draw_to_frame(&mut self, context: &CtxRef, frame: &nannou::Frame) {
+    pub fn draw_to_frame(
+        &mut self,
+        context: &CtxRef,
+        frame: &nannou::Frame,
+    ) -> Result<(), egui_wgpu_backend::BackendError> {
         let device_queue_pair = frame.device_queue_pair();
         let device = device_queue_pair.device();
         let queue = device_queue_pair.queue();
@@ -362,7 +369,7 @@ impl Renderer {
             size_pixels,
             scale_factor,
             texture_view,
-        );
+        )
     }
 }
 

--- a/nannou_egui_demo_app/Cargo.toml
+++ b/nannou_egui_demo_app/Cargo.toml
@@ -8,4 +8,4 @@ publish = false
 [dependencies]
 nannou_egui = { version = "0.4", path = "../nannou_egui" }
 nannou = "0.17.1"
-egui_demo_lib = { version = "0.13" }
+egui_demo_lib = { version = "0.14" }

--- a/nannou_egui_demo_app/Cargo.toml
+++ b/nannou_egui_demo_app/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 
 [dependencies]
 nannou_egui = { version = "0.4", path = "../nannou_egui" }
-nannou = "0.17.1"
-egui_demo_lib = { version = "0.14" }
+nannou = "0.18.1"
+egui_demo_lib = { version = "0.15" }

--- a/nannou_egui_demo_app/src/main.rs
+++ b/nannou_egui_demo_app/src/main.rs
@@ -49,5 +49,5 @@ fn update(app: &App, model: &mut Model, update: Update) {
 }
 
 fn view(_app: &App, model: &Model, frame: Frame) {
-    model.egui.draw_to_frame(&frame);
+    model.egui.draw_to_frame(&frame).unwrap();
 }


### PR DESCRIPTION
Also updates the methods that involve encoding the render pass to
propagate the egui_wgpu_backend `Result`.

TODO:

- [x] Switch from nannou git patch to new version once published.